### PR TITLE
Supporting Azurite to test pipelines locally

### DIFF
--- a/core/dbio/dbio_file_node.go
+++ b/core/dbio/dbio_file_node.go
@@ -3,6 +3,7 @@ package dbio
 import (
 	"errors"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -204,6 +205,10 @@ func ParseURL(uri string) (uType Type, host string, path string, err error) {
 	scheme := u.U.Scheme
 	host = u.Hostname()
 
+	if u.Port() != 0 {
+		host += ":" + strconv.Itoa(u.Port())
+	}
+
 	path = strings.TrimPrefix(u.U.Path, "/")
 	// g.Info("uri => %s, host => %s, path => %s (%s)", uri, host, path, u.U.Path)
 
@@ -216,6 +221,8 @@ func ParseURL(uri string) (uType Type, host string, path string, err error) {
 		return TypeFileAzure, host, path, nil
 	} else if scheme == "https" && strings.Contains(uri, "docs.google.com/spreadsheets") {
 		return TypeFileHTTP, host, path, nil
+	} else if scheme == "azurecustom-http" || scheme == "azurecustom-https" {
+		return TypeFileAzure, host, path, nil
 	}
 
 	uType, ok := ValidateType(scheme)

--- a/core/dbio/filesys/fs.go
+++ b/core/dbio/filesys/fs.go
@@ -135,7 +135,7 @@ func NewFileSysClientFromURL(url string, props ...string) (fsClient FileSysClien
 // props are provided as `"Prop1=Value1", "Prop2=Value2", ...`
 func NewFileSysClientFromURLContext(ctx context.Context, url string, props ...string) (fsClient FileSysClient, err error) {
 	switch {
-	case strings.HasPrefix(url, "azureCustom-http://") || strings.HasPrefix(url, "azureCustom-https://"):
+	case strings.HasPrefix(url, "azurecustom-http://") || strings.HasPrefix(url, "azurecustom-https://"):
 		props = append(props, "URL="+url)
 		return NewFileSysClientContext(ctx, dbio.TypeFileAzure, props...)
 	case strings.HasPrefix(url, "s3://"):

--- a/core/dbio/filesys/fs.go
+++ b/core/dbio/filesys/fs.go
@@ -135,6 +135,9 @@ func NewFileSysClientFromURL(url string, props ...string) (fsClient FileSysClien
 // props are provided as `"Prop1=Value1", "Prop2=Value2", ...`
 func NewFileSysClientFromURLContext(ctx context.Context, url string, props ...string) (fsClient FileSysClient, err error) {
 	switch {
+	case strings.HasPrefix(url, "azureCustom-http://") || strings.HasPrefix(url, "azureCustom-https://"):
+		props = append(props, "URL="+url)
+		return NewFileSysClientContext(ctx, dbio.TypeFileAzure, props...)
 	case strings.HasPrefix(url, "s3://"):
 		props = append(props, "URL="+url)
 		return NewFileSysClientContext(ctx, dbio.TypeFileS3, props...)
@@ -275,7 +278,9 @@ func NormalizeURI(fs FileSysClient, uri string) string {
 		}
 		return fs.Prefix("/") + path
 	default:
-		return fs.Prefix("/") + strings.TrimLeft(strings.TrimPrefix(uri, fs.Prefix()), "/")
+		prefix := fs.Prefix("/")
+		test := strings.TrimLeft(strings.TrimPrefix(uri, fs.Prefix()), "/")
+		return prefix + test
 	}
 }
 

--- a/core/dbio/filesys/fs_azure.go
+++ b/core/dbio/filesys/fs_azure.go
@@ -51,7 +51,7 @@ func (fs *AzureFileSysClient) Prefix(suffix ...string) string {
 
 		var blobEndpoint = connProps["BlobEndpoint"]
 		if blobEndpoint != "" {
-			return "azureCustom-" + blobEndpoint + "/" + fs.container + strings.Join(suffix, "")
+			return "azurecustom-" + blobEndpoint + "/" + fs.container + strings.Join(suffix, "")
 		}
 	}
 	return g.F("https://%s.blob.core.windows.net/%s", fs.account, fs.container) + strings.Join(suffix, "")
@@ -68,9 +68,9 @@ func (fs *AzureFileSysClient) GetPath(uri string) (path string, err error) {
 	}
 
 	pathContainer := strings.Split(path, "/")[0]
-	if !strings.HasPrefix(host, fs.account) && !strings.HasPrefix(uri, "azureCustom-") {
+	if !strings.HasPrefix(host, fs.account) && !strings.HasPrefix(uri, "azurecustom-") {
 		err = g.Error("URL account differs from connection account. %s != %s.blob.core.windows.net", host, fs.account)
-	} else if pathContainer != fs.container && !strings.HasPrefix(uri, "azureCustom-") {
+	} else if pathContainer != fs.container && !strings.HasPrefix(uri, "azurecustom-") {
 		err = g.Error("URL container differs from connection container. %s != %s", pathContainer, fs.container)
 	}
 


### PR DESCRIPTION
The Azure SDK supports the ability to utilize a custom Blob endpoint.  Similar to the following:

DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...;BlobEndpoint=http://azurite:10000/devstoreaccount1

This is useful when utilizing a tool such as Azurite to perform integration tests of data pipelines locally, from within a dockerized environment.  Unfortunately, the base Azure url is hard coded in a bunch of different locations.  There's a bit of a challenge trying to implement this feature due to the different locations where the Azure type is evaluated.

The approach feels a bit hacky - if a BlobEndpoint is defined in a connection string, it will implement a prefix to the custom Blob Endpoint's URI scheme called "azurecustom-".  Ideally, the Prefix code should probably detect the type of the URI, and adjust accordingly, but this was the simplest way for me to get this functionality working to allow me to connect to local Azurite container.